### PR TITLE
Update icon asset references

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>TrakkerTime PWA</title>
     <link rel="manifest" href="manifest.webmanifest">
+    <link rel="icon" href="icons/favicon.ico">
     <link rel="stylesheet" href="css/styles.css">
     <meta name="theme-color" content="#1f2937">
 </head>

--- a/js/service-worker.js
+++ b/js/service-worker.js
@@ -5,8 +5,8 @@ const ASSETS_TO_CACHE = [
   '/css/styles.css',
   '/js/app.js',
   '/manifest.webmanifest',
-  '/icons/icon-192.png',
-  '/icons/icon-512.png'
+  'icons/icon-192.png',
+  'icons/icon-512.png'
 ];
 
 self.addEventListener('install', (event) => {

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -8,12 +8,12 @@
   "description": "Track billable work from anywhere and sync with the TrakkerTime API.",
   "icons": [
     {
-      "src": "/icons/icon-192.png",
+      "src": "icons/icon-192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "/icons/icon-512.png",
+      "src": "icons/icon-512.png",
       "sizes": "512x512",
       "type": "image/png"
     }


### PR DESCRIPTION
## Summary
- update cached asset list to use the icons/ directory paths
- point manifest icon sources at the icons folder
- include the favicon link tag so the HTML references the icons bundle

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68cf3e6a8ba88333bbb688e778f4af0d