### PR TITLE
Move service worker to root

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -132,7 +132,7 @@ installButton?.addEventListener('click', async () => {
 
 if ('serviceWorker' in navigator) {
     window.addEventListener('load', () => {
-        navigator.serviceWorker.register('service-worker.js').catch((error) => {
+        navigator.serviceWorker.register('/service-worker.js').catch((error) => {
             console.error('Service worker registration failed', error);
         });
     });

--- a/service-worker.js
+++ b/service-worker.js
@@ -5,8 +5,8 @@ const ASSETS_TO_CACHE = [
   '/css/styles.css',
   '/js/app.js',
   '/manifest.webmanifest',
-  'icons/icon-192.png',
-  'icons/icon-512.png'
+  '/icons/icon-192.png',
+  '/icons/icon-512.png'
 ];
 
 self.addEventListener('install', (event) => {


### PR DESCRIPTION
## Summary
- move the service worker script to the project root so it deploys from the site root
- update cached asset paths to match the new location
- register the service worker using the root-relative URL

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68cf81e1a7148333a727ba8b05d5da07