### PR TITLE
Handle service worker scope-relative assets

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -130,24 +130,9 @@ installButton?.addEventListener('click', async () => {
     deferredInstallPrompt = null;
 });
 
-const registerServiceWorker = async () => {
-    const rootPath = '/service-worker.js';
-
-    try {
-        return await navigator.serviceWorker.register(rootPath);
-    } catch (error) {
-        const scopedPath = new URL('service-worker.js', window.location.href).pathname;
-        if (scopedPath !== rootPath) {
-            console.warn(`Service worker registration at ${rootPath} failed, retrying with ${scopedPath}.`, error);
-            return navigator.serviceWorker.register(scopedPath);
-        }
-        throw error;
-    }
-};
-
 if ('serviceWorker' in navigator) {
     window.addEventListener('load', () => {
-        registerServiceWorker().catch((error) => {
+        navigator.serviceWorker.register('/service-worker.js').catch((error) => {
             console.error('Service worker registration failed', error);
         });
     });

--- a/js/app.js
+++ b/js/app.js
@@ -130,9 +130,24 @@ installButton?.addEventListener('click', async () => {
     deferredInstallPrompt = null;
 });
 
+const registerServiceWorker = async () => {
+    const rootPath = '/service-worker.js';
+
+    try {
+        return await navigator.serviceWorker.register(rootPath);
+    } catch (error) {
+        const scopedPath = new URL('service-worker.js', window.location.href).pathname;
+        if (scopedPath !== rootPath) {
+            console.warn(`Service worker registration at ${rootPath} failed, retrying with ${scopedPath}.`, error);
+            return navigator.serviceWorker.register(scopedPath);
+        }
+        throw error;
+    }
+};
+
 if ('serviceWorker' in navigator) {
     window.addEventListener('load', () => {
-        navigator.serviceWorker.register('service-worker.js').catch((error) => {
+        registerServiceWorker().catch((error) => {
             console.error('Service worker registration failed', error);
         });
     });

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,20 +1,13 @@
-const CACHE_VERSION = 'v2';
-const CACHE_NAME = `trakkertime-cache-${CACHE_VERSION}`;
-
-const BASE_URL = new URL('./', self.location);
-
-const CORE_ASSETS = [
-  '.',
-  'index.html',
-  'css/styles.css',
-  'js/app.js',
-  'manifest.webmanifest',
-  'icons/icon-192.png',
-  'icons/icon-512.png'
+const CACHE_NAME = 'trakkertime-cache-v1';
+const ASSETS_TO_CACHE = [
+  '/',
+  '/index.html',
+  '/css/styles.css',
+  '/js/app.js',
+  '/manifest.webmanifest',
+  '/icons/icon-192.png',
+  '/icons/icon-512.png'
 ];
-
-const ASSETS_TO_CACHE = CORE_ASSETS.map((asset) => new URL(asset, BASE_URL).href);
-const OFFLINE_FALLBACK = new URL('index.html', BASE_URL).href;
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
@@ -64,7 +57,7 @@ self.addEventListener('fetch', (event) => {
           caches.open(CACHE_NAME).then((cache) => cache.put(event.request, responseClone));
           return networkResponse;
         })
-        .catch(() => caches.match(OFFLINE_FALLBACK));
+        .catch(() => caches.match('/index.html'));
     })
   );
 });

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,13 +1,20 @@
-const CACHE_NAME = 'trakkertime-cache-v1';
-const ASSETS_TO_CACHE = [
-  '/',
-  '/index.html',
-  '/css/styles.css',
-  '/js/app.js',
-  '/manifest.webmanifest',
+const CACHE_VERSION = 'v2';
+const CACHE_NAME = `trakkertime-cache-${CACHE_VERSION}`;
+
+const BASE_URL = new URL('./', self.location);
+
+const CORE_ASSETS = [
+  '.',
+  'index.html',
+  'css/styles.css',
+  'js/app.js',
+  'manifest.webmanifest',
   'icons/icon-192.png',
   'icons/icon-512.png'
 ];
+
+const ASSETS_TO_CACHE = CORE_ASSETS.map((asset) => new URL(asset, BASE_URL).href);
+const OFFLINE_FALLBACK = new URL('index.html', BASE_URL).href;
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
@@ -57,7 +64,7 @@ self.addEventListener('fetch', (event) => {
           caches.open(CACHE_NAME).then((cache) => cache.put(event.request, responseClone));
           return networkResponse;
         })
-        .catch(() => caches.match('/index.html'));
+        .catch(() => caches.match(OFFLINE_FALLBACK));
     })
   );
 });


### PR DESCRIPTION
## Summary
- add a helper that retries service worker registration with a scoped path when the root URL is unavailable so the install prompt can appear
- generate cache entries relative to the service worker scope and bump the cache version to pick up the corrected asset URLs
- serve the offline fallback from the scope-aware cache so it works when the app is hosted from a subdirectory

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68cf81e1a7148333a727ba8b05d5da07