### PR TITLE
Restore root service worker registration

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -132,7 +132,7 @@ installButton?.addEventListener('click', async () => {
 
 if ('serviceWorker' in navigator) {
     window.addEventListener('load', () => {
-        navigator.serviceWorker.register('service-worker.js').catch((error) => {
+        navigator.serviceWorker.register('/service-worker.js').catch((error) => {
             console.error('Service worker registration failed', error);
         });
     });

--- a/service-worker.js
+++ b/service-worker.js
@@ -5,8 +5,8 @@ const ASSETS_TO_CACHE = [
   '/css/styles.css',
   '/js/app.js',
   '/manifest.webmanifest',
-  'icons/icon-192.png',
-  'icons/icon-512.png'
+  '/icons/icon-192.png',
+  '/icons/icon-512.png'
 ];
 
 self.addEventListener('install', (event) => {


### PR DESCRIPTION
## Summary
- simplify the service worker registration to point directly at the root-level script
- restore the cache manifest to its original root-relative asset list while keeping the offline fallback to index.html

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_b_68cf81e1a7148333a727ba8b05d5da07