### PR TITLE
Improve service worker registration resilience

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -131,8 +131,24 @@ installButton?.addEventListener('click', async () => {
 });
 
 if ('serviceWorker' in navigator) {
+    const registerServiceWorker = async () => {
+        const candidateUrls = ['/service-worker.js', 'service-worker.js'];
+        let lastError = null;
+
+        for (const url of candidateUrls) {
+            try {
+                return await navigator.serviceWorker.register(url);
+            } catch (error) {
+                lastError = error;
+                console.warn(`Service worker registration failed for ${url}`, error);
+            }
+        }
+
+        throw lastError ?? new Error('Service worker registration failed for all candidate URLs.');
+    };
+
     window.addEventListener('load', () => {
-        navigator.serviceWorker.register('service-worker.js').catch((error) => {
+        registerServiceWorker().catch((error) => {
             console.error('Service worker registration failed', error);
         });
     });

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,17 +1,22 @@
-const CACHE_NAME = 'trakkertime-cache-v1';
-const ASSETS_TO_CACHE = [
-  '/',
-  '/index.html',
-  '/css/styles.css',
-  '/js/app.js',
-  '/manifest.webmanifest',
-  'icons/icon-192.png',
-  'icons/icon-512.png'
+const CACHE_NAME = 'trakkertime-cache-v2';
+const PRECACHE_ASSETS = [
+  './',
+  './index.html',
+  './css/styles.css',
+  './js/app.js',
+  './manifest.webmanifest',
+  './icons/icon-192.png',
+  './icons/icon-512.png'
 ];
+
+const getScopeUrl = () => self.registration?.scope ?? new URL('./', self.location).toString();
+const resolvePrecacheUrl = (path) => new URL(path, getScopeUrl()).toString();
+const getPrecacheUrls = () => PRECACHE_ASSETS.map((path) => resolvePrecacheUrl(path));
+const getOfflineFallbackUrl = () => resolvePrecacheUrl('./index.html');
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS_TO_CACHE))
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(getPrecacheUrls()))
   );
   self.skipWaiting();
 });
@@ -57,7 +62,7 @@ self.addEventListener('fetch', (event) => {
           caches.open(CACHE_NAME).then((cache) => cache.put(event.request, responseClone));
           return networkResponse;
         })
-        .catch(() => caches.match('/index.html'));
+        .catch(() => caches.match(getOfflineFallbackUrl()));
     })
   );
 });


### PR DESCRIPTION
## Summary
- add a fallback service worker registration path so `/service-worker.js` and scope-relative URLs both work
- resolve precache URLs against the controlling scope so installs succeed whether the app is served from the root or a subdirectory

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68cf81e1a7148333a727ba8b05d5da07